### PR TITLE
build: fix husky hooks to use nvm-managed Node 24

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,2 @@
-npx --no -- commitlint --edit $1
+. "$(dirname -- "$0")/setup-node.sh"
+npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+. "$(dirname -- "$0")/setup-node.sh"
 npx lint-staged

--- a/.husky/setup-node.sh
+++ b/.husky/setup-node.sh
@@ -1,0 +1,43 @@
+# Ensure the right Node.js version is on PATH for husky hooks.
+#
+# Husky hooks run via `sh -e` from a non-interactive environment, so any
+# nvm setup that lives in ~/.bashrc / ~/.zshrc is NOT loaded. On systems
+# where the distro provides an old `node` binary (e.g. Ubuntu 20.04 ships
+# Node 10), the hook would resolve `node` to that obsolete version and
+# fail to run modern dev tooling like lint-staged or commitlint.
+#
+# This script:
+#   1. Sources nvm (if installed) so `nvm` and `node` are usable
+#   2. Activates Node 24 (matches package.json#engines.node), or nvm's default
+#   3. Force-prepends the active Node bin dir to PATH, since some nvm
+#      versions skip that step in non-interactive shells
+#
+# Sourced from .husky/pre-commit and .husky/commit-msg.
+# Silently no-ops on machines without nvm, leaving the system Node in place.
+
+NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+export NVM_DIR
+
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+    # shellcheck disable=SC1091
+    . "$NVM_DIR/nvm.sh" --no-use
+
+    if nvm ls 24 >/dev/null 2>&1; then
+        nvm use 24 >/dev/null 2>&1 || true
+    else
+        nvm use default >/dev/null 2>&1 || true
+    fi
+
+    NVM_VERSION="$(nvm current 2>/dev/null || true)"
+    case "$NVM_VERSION" in
+        v*)
+            NVM_NODE_BIN="$NVM_DIR/versions/node/$NVM_VERSION/bin"
+            if [ -d "$NVM_NODE_BIN" ]; then
+                case ":$PATH:" in
+                    *":$NVM_NODE_BIN:"*) ;;
+                    *) export PATH="$NVM_NODE_BIN:$PATH" ;;
+                esac
+            fi
+            ;;
+    esac
+fi


### PR DESCRIPTION
## Summary
- Husky pre-commit and commit-msg hooks fell back to system Node (v10 on Ubuntu 20.04) because nvm setup in `~/.bashrc` is not sourced in non-interactive shells, breaking lint-staged and commitlint with `SyntaxError: Unexpected token {`.
- Add `.husky/setup-node.sh` that sources nvm, activates Node 24 (matching `package.json#engines.node`), and force-prepends the Node bin to `PATH`. Sourced from both hooks. No-ops on machines without nvm.

## Test plan
- [x] `git commit` succeeds without manual `PATH` overrides on a machine where the system Node is too old (verified — commit `ab464bb` was created with the fix in place using only the default WSL shell).
- [ ] Reviewer checkout: clone fresh, run `npm install`, make a trivial change, `git commit -m "test: ..."` → hooks pass.
- [ ] CI lint workflow still passes.